### PR TITLE
refactor: use .cjs config, optional settings, and clean up control flow

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -11,7 +11,7 @@ on:
       - '.github/workflows/development.yml'
       - '.github/workflows/reusable-build.yml'
       - 'src/**'
-      - 'husky-hooks.config.default.js'
+      - 'husky-hooks.config.default.cjs'
       - 'package.json'
       - 'tsconfig.json'
       - 'jestconfig.json'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
       - '.github/workflows/main.yml'
       - '.github/workflows/reusable-build.yml'
       - 'src/**'
-      - 'husky-hooks.config.default.js'
+      - 'husky-hooks.config.default.cjs'
       - 'package.json'
       - 'tsconfig.json'
       - 'jestconfig.json'

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -99,7 +99,7 @@ jobs:
       # --- Config management ---
 
       - name: Ensure no existing config
-        run: rm -f husky-hooks.config.js
+        run: rm -f husky-hooks.config.cjs
 
       - name: "E2E: create-config"
         run: npx @jeliasson/husky-hooks create-config
@@ -120,13 +120,11 @@ jobs:
         run: |
           branch=$(git branch --show-current)
           echo "Current branch: $branch"
-          cat > husky-hooks.config.js << CONF
+          cat > husky-hooks.config.cjs << CONF
           const config = {
             hooks: { 'pre-commit': ['check-branch'] },
             settings: {
               'check-branch': { protectedBranches: ['$branch'] },
-              'check-lock-files': { allowLockFile: 'package-lock.json', denyLockFiles: [] },
-              'test-sleep': { delay: 0 },
             },
           }
           module.exports = config
@@ -140,7 +138,7 @@ jobs:
 
       - name: Update config for hook execution tests
         run: |
-          cat > husky-hooks.config.js << 'CONF'
+          cat > husky-hooks.config.cjs << 'CONF'
           const config = {
             hooks: {
               'pre-commit': [
@@ -152,9 +150,7 @@ jobs:
               ],
             },
             settings: {
-              'check-branch': { protectedBranches: [] },
               'check-lock-files': { allowLockFile: 'package-lock.json', denyLockFiles: ['yarn.lock', 'pnpm-lock.yaml'] },
-              'test-sleep': { delay: 0 },
             },
           }
           module.exports = config

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 lib
 node_modules
-husky-hooks.config.js
+husky-hooks.config.cjs

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ echo "npx @jeliasson/husky-hooks pre-commit" > .husky/pre-commit
 echo "npx @jeliasson/husky-hooks pre-push" > .husky/pre-push
 ```
 
-Create a config file. `husky-hooks.config.js` will be placed in the root folder of the project.
+Create a config file. `husky-hooks.config.cjs` will be placed in the root folder of the project.
 
 ```bash
 npx @jeliasson/husky-hooks create-config
@@ -76,13 +76,13 @@ Invalid occurrence of "yarn.lock" file. Please remove it and only use "package-l
 
 ## Hooks
 
-Hooks are defined in the configuration file `husky-hooks.config.js`. You can assign them to any git hook event (`pre-commit`, `pre-push`, `commit-msg`, `post-merge`, etc.).
+Hooks are defined in the configuration file `husky-hooks.config.cjs`. You can assign them to any git hook event (`pre-commit`, `pre-push`, `commit-msg`, `post-merge`, etc.).
 
-| Name                                    | Description                                                              |
-| --------------------------------------- | ------------------------------------------------------------------------ |
-| [`check-branch`](#check-branch)         | Abort if the current git branch is protected.                            |
-| [`check-lock-files`](#check-lock-files) | Abort if unwanted package manager lock files are present.                |
-| [`run-cmd`](#run-cmd)                   | Run an ad-hoc command and abort if it fails.                             |
+| Name                                    | Description                                               |
+| --------------------------------------- | --------------------------------------------------------- |
+| [`check-branch`](#check-branch)         | Abort if the current git branch is protected.             |
+| [`check-lock-files`](#check-lock-files) | Abort if unwanted package manager lock files are present. |
+| [`run-cmd`](#run-cmd)                   | Run an ad-hoc command and abort if it fails.              |
 
 #### `check-branch`
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,8 +7,8 @@ export default [
   js.configs.recommended,
   {
     ignores: [
-      "husky-hooks.config.js",
-      "husky-hooks.config.default.js",
+      "husky-hooks.config.cjs",
+      "husky-hooks.config.default.cjs",
       "prettier.config.js",
       "lib/*"
     ],

--- a/husky-hooks.config.default.cjs
+++ b/husky-hooks.config.default.cjs
@@ -3,14 +3,12 @@
 const config = {
   hooks: {
     'pre-commit': [
-      'test-sleep', // This is a dummy hook for demo purposes
       'check-branch',
       'check-lock-files',
       ['run-cmd', 'echo Test'],
     ],
 
     'pre-push': [
-      'test-sleep', // This is a dummy hook for demo purposes
       'check-branch',
       'check-lock-files',
       ['run-cmd', 'echo Test'],
@@ -43,17 +41,6 @@ const config = {
 
       // Package manager lock files that should yield a abort
       denyLockFiles: ['yarn.lock', 'pnpm-lock.yaml'],
-    },
-
-    /**
-     * test-sleep
-     *
-     * This is a dummy hook for demo purposes. It sleeps for 1000 seconds
-     * before continuing to next hook.
-     */
-    'test-sleep': {
-      // How long should the hook sleep for
-      delay: 1000,
     },
   },
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jeliasson/husky-hooks",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "license": "MIT",
   "description": "Increase the developer experience and consistency by providing a set of hooks that can be opted-in the development lifecycle.",
   "author": "jeliasson",
@@ -42,7 +42,7 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib/**/*",
-    "husky-hooks.config.default.js"
+    "husky-hooks.config.default.cjs"
   ],
   "bin": {
     "husky-hooks": "lib/bin.js"

--- a/src/__tests__/commands.test.ts
+++ b/src/__tests__/commands.test.ts
@@ -19,7 +19,7 @@ describe('commands', () => {
       }
     })
 
-    it('should return false when command name is not registered', async () => {
+    it('should return false when command is not registered', async () => {
       const result = await runCommand('unknown-cmd')
       expect(result).toBe(false)
     })

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -45,12 +45,22 @@ describe('ConfigSchema validation', () => {
     expect(result.success).toBe(true)
   })
 
-  it('should reject config with missing settings', () => {
+  it('should accept config with empty settings', () => {
     const result = ConfigSchema.safeParse({
       ...validConfig,
       settings: {},
     })
-    expect(result.success).toBe(false)
+    expect(result.success).toBe(true)
+  })
+
+  it('should accept config with only some settings', () => {
+    const result = ConfigSchema.safeParse({
+      ...validConfig,
+      settings: {
+        'check-branch': { protectedBranches: ['main'] },
+      },
+    })
+    expect(result.success).toBe(true)
   })
 
   it('should reject invalid hook names in hook arrays', () => {

--- a/src/__tests__/createConfigCommand.test.ts
+++ b/src/__tests__/createConfigCommand.test.ts
@@ -1,20 +1,23 @@
 import { createConfigCommand } from '../commands'
-import { CLIError } from '../response'
 import * as config from '../config'
 import * as cli from '../cli'
 
 jest.mock('../config', () => ({
   ...jest.requireActual('../config'),
   createConfig: jest.fn(),
-  CONFIG_FILE: 'husky-hooks.config.js',
+  CONFIG_FILE: 'husky-hooks.config.cjs',
 }))
 
 jest.mock('../cli', () => ({
   CLIParser: jest.fn(),
 }))
 
-const mockedCreateConfig = config.createConfig as jest.MockedFunction<typeof config.createConfig>
-const mockedCLIParser = cli.CLIParser as jest.MockedFunction<typeof cli.CLIParser>
+const mockedCreateConfig = config.createConfig as jest.MockedFunction<
+  typeof config.createConfig
+>
+const mockedCLIParser = cli.CLIParser as jest.MockedFunction<
+  typeof cli.CLIParser
+>
 
 describe('createConfigCommand', () => {
   afterEach(() => {
@@ -32,25 +35,26 @@ describe('createConfigCommand', () => {
   })
 
   it('should call createConfig with force=true when --force is passed', async () => {
-    mockedCLIParser.mockResolvedValue({ args: ['create-config'], opts: { force: true } })
-    mockedCreateConfig.mockResolvedValue(false)
+    mockedCLIParser.mockResolvedValue({
+      args: ['create-config'],
+      opts: { force: true },
+    })
+    mockedCreateConfig.mockResolvedValue(true)
 
     await createConfigCommand()
 
     expect(mockedCreateConfig).toHaveBeenCalledWith(true)
   })
 
-  it('should throw CLIError with exit code 0 when config is created', async () => {
+  it('should return success message when config is created', async () => {
     mockedCLIParser.mockResolvedValue({ args: ['create-config'], opts: {} })
-    mockedCreateConfig.mockResolvedValue({ hooks: {}, settings: {} } as never)
+    mockedCreateConfig.mockResolvedValue(true)
 
-    try {
-      await createConfigCommand()
-      fail('should have thrown')
-    } catch (error) {
-      expect(error).toBeInstanceOf(CLIError)
-      expect((error as CLIError).exitCode).toBe(0)
-      expect((error as CLIError).message).toContain('was created')
-    }
+    const result = await createConfigCommand()
+
+    expect(result.stdout).toEqual(
+      expect.arrayContaining([expect.stringContaining('was created')])
+    )
+    expect(result.errors).toEqual([])
   })
 })

--- a/src/__tests__/response.test.ts
+++ b/src/__tests__/response.test.ts
@@ -1,4 +1,4 @@
-import { CLIError, ThrowSuccess, ThrowError, ThrowException, createResponse } from '../response'
+import { CLIError, ThrowError, ThrowException, createResponse } from '../response'
 
 describe('response', () => {
   describe('CLIError', () => {
@@ -13,29 +13,6 @@ describe('response', () => {
     it('should default exit code to 1', () => {
       const error = new CLIError(['oops'])
       expect(error.exitCode).toBe(1)
-    })
-  })
-
-  describe('ThrowSuccess', () => {
-    it('should throw CLIError with exit code 0', () => {
-      try {
-        ThrowSuccess(['Done'])
-        fail('should have thrown')
-      } catch (error) {
-        expect(error).toBeInstanceOf(CLIError)
-        expect((error as CLIError).exitCode).toBe(0)
-        expect((error as CLIError).messages).toEqual(['Done'])
-      }
-    })
-
-    it('should join multiple messages', () => {
-      try {
-        ThrowSuccess(['Line 1', 'Line 2'])
-        fail('should have thrown')
-      } catch (error) {
-        expect((error as CLIError).message).toContain('Line 1')
-        expect((error as CLIError).message).toContain('Line 2')
-      }
     })
   })
 

--- a/src/__tests__/validateConfig.test.ts
+++ b/src/__tests__/validateConfig.test.ts
@@ -10,8 +10,6 @@ describe('validateConfig', () => {
     },
     settings: {
       'check-branch': { protectedBranches: ['main'] },
-      'check-lock-files': { allowLockFile: 'package-lock.json', denyLockFiles: [] },
-      'test-sleep': { delay: 100 },
     },
   }
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -5,9 +5,7 @@ import { CLIError } from './response.js'
 
 init().catch((error: unknown) => {
   if (error instanceof CLIError) {
-    if (error.exitCode === 0) {
-      console.log(`\nAll good!\n\n${error.messages.join('\n')}`)
-    } else if (error.messages.length > 0) {
+    if (error.messages.length > 0) {
       console.log(`\nError\n\n${error.messages.join('\n')}`)
     }
     process.exit(error.exitCode)

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,27 +1,26 @@
 import { CONFIG_FILE, PACKAGE_NAME, createConfig } from './config'
-import { Commands } from './types'
+import { CommandResponse, Commands } from './types'
 
 import { CLIParser } from './cli'
-import { ThrowError, ThrowSuccess, createResponse } from './response'
+import { ThrowError } from './response'
 
-export async function createConfigCommand(): Promise<{ stdout: string[]; errors: string[] }> {
-  const { stdout, errors } = createResponse()
-
+export async function createConfigCommand(): Promise<CommandResponse> {
   const cli = await CLIParser()
   const { force } = cli.opts
 
-  const config = await createConfig(force === true || false)
+  const created = await createConfig(force === true || false)
 
-  if (config) ThrowSuccess([`Config file '${CONFIG_FILE}' was created.`])
-
-  return { stdout, errors }
+  return {
+    stdout: created ? [`Config file '${CONFIG_FILE}' was created.`] : [],
+    errors: [],
+  }
 }
 
 export const commands: Commands = {
   'create-config': createConfigCommand,
 }
 
-export async function runCommand(name: string): Promise<boolean> {
+export async function runCommand(name: string): Promise<CommandResponse | false> {
   if (!name) {
     ThrowError([
       `Missing command, e.g. create-config.`,
@@ -32,8 +31,7 @@ export async function runCommand(name: string): Promise<boolean> {
 
   const command = commands[name]
   if (typeof command === 'function') {
-    await command()
-    return true
+    return await command()
   }
 
   return false

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,15 +1,15 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { Config, ConfigSchema, SettingsName } from './types'
+import { Config, ConfigSchema, RequiredSettings, SettingsName } from './types'
 
 import { CLIError, ThrowError, ThrowException } from './response'
 
 const fsp = fs.promises
 
 export const PACKAGE_NAME = '@jeliasson/husky-hooks'
-export const CONFIG_FILE = 'husky-hooks.config.js'
-export const ORIGINAL_CONFIG_FILE = 'husky-hooks.config.default.js'
+export const CONFIG_FILE = 'husky-hooks.config.cjs'
+export const ORIGINAL_CONFIG_FILE = 'husky-hooks.config.default.cjs'
 
 function getConfigPath(): string {
   return path.join(process.cwd(), CONFIG_FILE)
@@ -39,7 +39,7 @@ export async function getConfig(): Promise<Config> {
   return require(configPath)
 }
 
-export async function createConfig(force = false): Promise<Config | false> {
+export async function createConfig(force = false): Promise<boolean> {
   const originalConfig = getDefaultConfigPath()
   const configPath = getConfigPath()
 
@@ -58,12 +58,13 @@ export async function createConfig(force = false): Promise<Config | false> {
   try {
     await fsp.copyFile(originalConfig, configPath)
 
-    return require(configPath)
-  } catch {
-    ThrowException([`An error occurred while creating ${CONFIG_FILE}`])
+    return true
+  } catch (error) {
+    ThrowException([
+      `An error occurred while creating ${CONFIG_FILE}`,
+      String(error),
+    ])
   }
-
-  return false
 }
 
 export async function validateConfig(config: Config): Promise<Config> {
@@ -105,15 +106,21 @@ export async function validateConfig(config: Config): Promise<Config> {
 
 export async function getSettings<T extends SettingsName>(
   name: T
-): Promise<Config['settings'][T]> {
+): Promise<RequiredSettings[T]> {
   const config = await getConfig()
-  return config.settings[name]
+  const settings = config.settings[name]
+  if (!settings)
+    ThrowError([
+      `Missing settings for "${name}" in ${CONFIG_FILE}.`,
+      `Add a "${name}" section under settings to use this hook.`,
+    ])
+  return settings as RequiredSettings[T]
 }
 
 export async function getSetting<
   T extends SettingsName,
-  K extends keyof Config['settings'][T],
->(name: T, key: K): Promise<Config['settings'][T][K]> {
-  const config = await getConfig()
-  return config.settings[name][key]
+  K extends keyof RequiredSettings[T],
+>(name: T, key: K): Promise<RequiredSettings[T][K]> {
+  const settings = await getSettings(name)
+  return settings[key]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,15 @@ export async function init(): Promise<void> {
   const { args, opts } = await CLIParser()
 
   const [command] = args
-  const handled = await runCommand(command)
-  if (handled) return
+  const result = await runCommand(command)
+  if (result) {
+    result.stdout.forEach((line: string) => console.log(line))
+    if (result.errors.length > 0) {
+      result.errors.forEach((error: string) => console.error(error))
+      throw new CLIError([], 1)
+    }
+    return
+  }
 
   const config = await getConfig()
   await validateConfig(config)

--- a/src/response.ts
+++ b/src/response.ts
@@ -14,10 +14,6 @@ export function ThrowError(messages: string[]): never {
   throw new CLIError(messages, 1)
 }
 
-export function ThrowSuccess(messages: string[]): never {
-  throw new CLIError(messages, 0)
-}
-
 export function ThrowException(messages: string[]): never {
   const formatted = messages.join('\n')
   throw new Error(`\n\nException\n\n${formatted}\n\nStack trace\n`)

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,10 @@ export type Config = z.infer<typeof ConfigSchema>
 
 export type SettingsName = keyof Config['settings']
 
+export type RequiredSettings = {
+  [K in SettingsName]: NonNullable<Config['settings'][K]>
+}
+
 const HookNames = [
   'check-branch',
   'check-lock-files',
@@ -50,13 +54,13 @@ export const ConfigSchema = z.object({
   settings: z.object({
     'check-branch': z.object({
       protectedBranches: z.array(z.string()),
-    }),
+    }).optional(),
     'check-lock-files': z.object({
       allowLockFile: z.string(),
       denyLockFiles: z.array(z.string()),
-    }),
+    }).optional(),
     'test-sleep': z.object({
       delay: z.number().min(0),
-    }),
+    }).optional(),
   }),
 })


### PR DESCRIPTION
Config file renamed from husky-hooks.config.js to husky-hooks.config.cjs to support projects with "type": "module" in package.json. Existing users must rename their config file.

- Rename config files from .js to .cjs for ESM compatibility
- Make all settings blocks optional in ConfigSchema so users only need to configure hooks they actually use
- Remove test-sleep and test-check-ip from default config
- Fix createConfig always returning false (success message never shown)
- Replace ThrowSuccess error-as-control-flow with proper return values
- Surface underlying error in createConfig catch block